### PR TITLE
Token service dummy2

### DIFF
--- a/client/src/main.js
+++ b/client/src/main.js
@@ -5,8 +5,10 @@ import VueRouter from 'vue-router';
 import router from './routes.js';
 import vuetify from './plugins/vuetify';
 import constants from '@/utils/constants'
+import axiosPlugin from './plugins/axiosPlugin';
 
 Vue.use(VueRouter);
+Vue.use(axiosPlugin);
 
 Vue.config.productionTip = false
 

--- a/client/src/plugins/axiosPlugin.js
+++ b/client/src/plugins/axiosPlugin.js
@@ -1,0 +1,31 @@
+import axios from 'axios';
+
+const AxiosPlugin = {};
+
+// AxiosPlugin.install = (_Vue, _options) => {
+AxiosPlugin.install = () => {
+    // const store = options.store;
+    // let token = options.store.getters.token;
+
+    const token = "MTYwODY3NDk0NC42NjUzMzk3";
+
+    axios.interceptors.request.use(config => {
+        // Send cookie in request
+        console.log('intercept request');
+        config.params = {...config.params, token}
+        console.log(config.params);
+        return config;
+    }, error => {
+        // Do something with request error
+        return Promise.reject(error);
+    });
+
+    // Add a response interceptor
+    axios.interceptors.response.use(response => {
+        return response;
+    }, error => {
+        return Promise.reject(error);
+    });
+};
+
+export default AxiosPlugin;

--- a/pathology-viewer-flask/app/requirements.txt
+++ b/pathology-viewer-flask/app/requirements.txt
@@ -1,17 +1,22 @@
-autopep8 >=     1.5.4
-click     >=    7.1.2
-cppyy      >=   1.8.0
-cppyy-backend >= 1.12.1
-cppyy-cling >=  6.21.0
-CPyCppyy    >=  1.11.1
-Flask      >=   1.1.2
-itsdangerous >= 1.1.0
-Jinja2     >=   2.11.2
-MarkupSafe >=   1.1.1
-numpy      >=   1.19.1
-opencv-python >= 4.3.0.36
-pycodestyle >=  2.6.0
-setuptools  >=  41.2.0
-toml       >=   0.10.1
-Werkzeug    >=  1.0.1
-flask-cors >=3.0.8
+autopep8==1.5.4
+certifi==2020.12.5
+chardet==4.0.0
+click==7.1.2
+cppyy==1.9.1
+cppyy-backend==1.14.1
+cppyy-cling==6.21.4
+CPyCppyy==1.12.0
+Flask==1.1.2
+Flask-Cors==3.0.9
+idna==2.10
+itsdangerous==1.1.0
+Jinja2==2.11.2
+MarkupSafe==1.1.1
+numpy==1.19.4
+opencv-python==4.4.0.46
+pycodestyle==2.6.0
+requests==2.25.1
+six==1.15.0
+toml==0.10.2
+urllib3==1.26.2
+Werkzeug==1.0.1

--- a/token-service/README.md
+++ b/token-service/README.md
@@ -1,6 +1,26 @@
 # Token service
 
+### Installing dependencies
+
+```
+pip install -r requirements.txt
+```
+
+### Runnint the service
+
+Run on port 5001
+```
+FLASK_RUN_PORT=5001 flask run
+```
+
+```
+python app.py
+```
+
 ### Build docker image
+
+Edit Dockerfile if needed:
+FLASK_RUN_PORT=<PORT_NUMBER>  # default 5001
 
 ```
 make build_image
@@ -11,3 +31,5 @@ make build_image
 ```
 make dev_run
 ```
+
+

--- a/token-service/app/app.py
+++ b/token-service/app/app.py
@@ -1,31 +1,55 @@
 import os, io, logging, json
-from flask import Flask, request
+from flask import Flask, request, make_response
 from flask_cors import CORS, cross_origin
+import time
+import base64
 
 app = Flask(__name__)
 
 cors = CORS(app)
 app.config['CORS_HEADERS'] = 'Content-Type'
 
+TOKEN_DURATION = 10 * 60; # token duration in seconds (10 minutes)
+
 
 @app.route("/") 
 def index():
     return "Token service.<br>GET /validate<br>POST /create"
 
-@app.route("/validate/<path:token>/", methods=['GET'])
+@app.route("/validate/<path:token>", methods=['GET'])
 @cross_origin()
 def validate(token):
-    return json.loads(json.dumps(
-        {
-            "token_ok": token
-        }))
+    try:
+        token_decoded = base64.b64decode(token)
+        token = float(token_decoded)
+        now = time.time()
 
-@app.route("/create/<path:token>/", methods=['POST'])
+        delta = token - now
+
+        if delta > 0:
+            return json.loads(json.dumps(
+                {
+                    "ok": token
+                }))
+        else:
+            return make_response('Token has expired', 403)
+    except:
+        return make_response('Error parsing token', 400)
+
+
+
+@app.route("/create", methods=['POST'])
 @cross_origin()
-def create(token):
+def create():
+    now = time.time(); # seconds since 1970
+    exp_time = now + TOKEN_DURATION
+
+    token_bytes = str(exp_time).encode('ascii')
+    token_base64 = base64.b64encode(token_bytes)
+
     return json.loads(json.dumps(
         {
-            "create_token": token
+            "token": token_base64.decode('ascii')
         }))
 
 # Set log configuration


### PR DESCRIPTION
**Token servis:**
endpoint POST /create 
vraca token u obliku:
```
{
 token: <base64token>
}
```

endpoint GET /validate/<base64token>
vraca status OK, ili 400/403 ako nije ok

Po defaultu token traje 10minuta

**App Backend:**
dodat je middlevare koji proverava token:

ukoliko je token nevalidan prosledjuje se status sa token servisa (400/403).
Takodje, dodao sam listu endpointa za koje se token ne validira:
`excluded_endpoints = ["/api/region"]¬ `
tu je /api/region.
To je jedini poziv sa frontenda za koji se ne koristi axios. On je u TileLayer-u setovan i moralo bi da se vodi racuna da se taj url updateuje svaki put kad se promeni token... to ostavljam vama da odlucite da li da ostane ovako ili ce se dodati token i na taj poziv.


**Frontend:**

Dodat je plugins/axiosPlugin.js
On je za sad prilicno prazan, i sa hardkodiranim tokenom (koji je istekao u vreme kad ovo citate :D ).
Iz plugina moze da se pristupi storu i da se recimo odatle cita token... itd....




