### PR TITLE
Token service dummy3

### DIFF
--- a/pathology-viewer-flask/docker-compose.yml
+++ b/pathology-viewer-flask/docker-compose.yml
@@ -11,5 +11,8 @@ services:
     tty: True
   token:
     image: token-service:latest
+    restart: on-failure
+    environment:
+      TOKEN_DURATION: 600
     ports:
       - "5001:5001"

--- a/token-service/Dockerfile
+++ b/token-service/Dockerfile
@@ -18,12 +18,14 @@ RUN pip3 install -r /app/requirements.txt
 # Copy required files to container
 COPY app /app
 
-# Setup environement 
+# Setup environement
+# set TOKEN_DURATION in seconds
 WORKDIR /app
 ENV LC_ALL=C.UTF-8 \
     LANG=C.UTF-8 \
     FLASK_APP=/app/app.py \
     FLASK_ENV=development \
+    TOKEN_DURATION=600 \
     FLASK_RUN_PORT=5001
 
 # Start flask

--- a/token-service/Makefile
+++ b/token-service/Makefile
@@ -5,6 +5,7 @@ build_image:
 # Run DockerDev Image
 dev_run:
 	docker run --rm -it\
+		--env TOKEN_DURATION=700\
 		--name tokenService\
 		--net=host\
 		token-service:latest

--- a/token-service/README.md
+++ b/token-service/README.md
@@ -32,4 +32,26 @@ make build_image
 make dev_run
 ```
 
+### Token duration
 
+Token duration is read from env variable TOKEN_DURATION.
+If TOKEN_DURATION is not set, token service falls bakc to defatul value 600s (10minutes).
+
+When running as python/flask app token service can be set in similar way as FLASK_RUN_PORT:
+```
+TOKEN_DURATION=700 FLASK_RUN_PORT=5001 flaks run
+```
+
+Also TOKEN_DURATION default value may be changed during the docker image build process (change the value in Dockerfile, and rebuild the image.
+
+And, finally, most elegant way (it doesn't require rebuilding of the code, or the docker image) is to pass TOKEN_DURATION to docker run command: 
+
+```
+	docker run --rm -it\
+		--env TOKEN_DURATION=700\
+		--name tokenService\
+		--net=host\
+		token-service:latest
+```
+
+or simply edit 'dev_run' target in Makefile and change TOKEN_DURATION value.

--- a/token-service/app/app.py
+++ b/token-service/app/app.py
@@ -9,8 +9,11 @@ app = Flask(__name__)
 cors = CORS(app)
 app.config['CORS_HEADERS'] = 'Content-Type'
 
-TOKEN_DURATION = 10 * 60; # token duration in seconds (10 minutes)
+TOKEN_DURATION = os.getenv('TOKEN_DURATION')
+if TOKEN_DURATION == None:
+    TOKEN_DURATION = 10 * 60; # token duration in seconds (10 minutes)
 
+print('TOKEN_DURATION ' + TOKEN_DURATION)
 
 @app.route("/") 
 def index():


### PR DESCRIPTION
Dodata je env varijabla TOKEN_DURATION kojom moze da se definise trajanje tokena u sekundama.
Ima vise nacina da se setuje. Uputsvo je u Readme fajlu u token-service.
